### PR TITLE
Remove unused namesapces and fix namesapces

### DIFF
--- a/tests/ContainerServiceCacheTest.php
+++ b/tests/ContainerServiceCacheTest.php
@@ -5,7 +5,6 @@ namespace PHPWatch\SimpleContainer\Tests;
 use PHPWatch\SimpleContainer\Container;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use function foo\func;
 
 class ContainerServiceCacheTest extends TestCase {
     public function testStandardServiceResolutionInInit(): void {

--- a/tests/ContainerStaticValuesTest.php
+++ b/tests/ContainerStaticValuesTest.php
@@ -5,7 +5,6 @@ namespace PHPWatch\SimpleContainer\Tests;
 use Exception;
 use PHPWatch\SimpleContainer\Container;
 use PHPUnit\Framework\TestCase;
-use PHPWatch\SimpleContainer\Exception\NotFoundException;
 use stdClass;
 
 class ContainerStaticValuesTest extends TestCase {

--- a/tests/Exception/NotFoundExceptionTest.php
+++ b/tests/Exception/NotFoundExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PHPWatch\SimpleContainer\Tests;
+namespace PHPWatch\SimpleContainer\Tests\Exception;
 
 use PHPWatch\SimpleContainer\Container;
 use PHPWatch\SimpleContainer\Exception\NotFoundException;


### PR DESCRIPTION
# Changed log

- Remove some namespaces because they're declared, but not used.
- Fix the `NotFoundExceptionTest` class namespace to be `namespace PHPWatch\SimpleContainer\Tests\Exception;`