### PR TITLE
Fixed readme composer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A fast and minimal PSR-11 compatible Dependency Injection Container with array-s
 ## Installation  
   
 ```bash  
-composer install phpwatch/simple-container  
+composer require phpwatch/simple-container
 ``` 
 
 ## Usage  


### PR DESCRIPTION
Thank you for creating the package, here's my small contribution.

```sh
$ composer install phpwatch/simple-container
Invalid argument phpwatch/simple-container. Use "composer require phpwatch/simple-container" instead to add packages to your composer.
json.
```