### PR TITLE
Suppress notice

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -88,6 +88,7 @@ class Container implements ArrayAccess, ContainerInterface {
 		return array_key_exists($id, $this->definitions);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetGet(mixed $id): mixed {
 		return $this->getService($id);
 	}


### PR DESCRIPTION
Adding the proposed annotation to prevent the following notice:

.../vendor/phpwatch/simple-container/src/Container.php(13): 8192 (UNKNOWN): Return type of PHPWatch\SimpleContainer\Container::offsetGet($id) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice (.../vendor/phpwatch/simple-container/src/Container.php:91)
